### PR TITLE
Обновление корневого и модульных README; изменение пайплайна

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -13,6 +13,7 @@ jobs:
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
+    if: ${{ github.ref == "refs/heads/main" || github.event_name == "workflow_dispatch" }}
 
     steps:
     - name: Checkout the repo

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -13,7 +13,7 @@ jobs:
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
-    if: ${{ github.ref == "refs/heads/main" || github.event_name == "workflow_dispatch" }}
+    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
 
     steps:
     - name: Checkout the repo

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Selectel infra terraform modules example
+# Selectel Terraform Modules Example
 
 [![Test Selectel Terraform modules](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml)
 
-> Для работы с облачными ресурсами в Selectel через `terraform` будет не лишним ознакомиться с документацией по работе с `terraform providers openstack/selectel` на [офф. странице.](https://docs.selectel.ru/terraform/)
-
-В данном репозитории находятся примеры terraform модулей, используемых для создания инфраструктуры в облаке Selectel.
+Перед началом работы с облачными ресурсами Selectel через Terraform рекомендуем ознакомиться с [документацией по провайдеру Selectel/OpenStack](https://docs.selectel.ru/terraform/). В [данном репозитории](https://github.com/selectel/selectel-infra-examples) находятся примеры Terraform модулей, используемых для создания инфраструктуры в облаке Selectel.
 
 ## Usage
 
-1. Инициализировать terraform backend
+1. Инициализировать Terraform Backend
+
 ```bash
 terraform init
 ```
 
-2. Создать файл `main.tf`,  где описана необходимая инфраструктура (пример ниже - создание `simple file storage`)
+2. Создать файл `main.tf`, где описана необходимая инфраструктура (пример ниже - создание `Simple File Storage`)
+
 ```yaml
 module "sfs" {
   source               = "modules/sfs"
@@ -26,6 +26,8 @@ module "sfs" {
 ```
 
 3. Для проверки и применения настроек необходимо запустить команды `terraform plan/apply`
+
+
 ```bash
 terraform plan
 terraform apply
@@ -35,30 +37,40 @@ terraform apply
 
 В репозитории можно найти пример использования модулей. В корне репозитория созданы `*.tf` файлы, которые можно использовать как пример вызова модулей.
 
-Для их использования достаточно перейти в корень репозитория и инициализоровать terraform:
+Для их использования достаточно перейти в корень репозитория и инициализировать Terraform:
 
 ```bash
 terraform init
 ```
 
-Далее можно скорректировать некоторые параметры в файле `main.tf`, которые передаются в модули, например, объём sfs, имя кластера и другие.
+Далее можно скорректировать некоторые параметры в файле `main.tf`, которые передаются в модули, например, объём SFS, имя кластера и другие.
 
-Теперь можно выполнить комадны `terraform plan/apply`, но чтобы terraform знал, где именно ему все это запускать, необходимо указать значения переменных:
+Затем необходимо задать переменные, в которых будут содержаться данные от аккаунта Selectel, в котором будет развёрнута инфраструктура:
 
 - `selectel_domain_name`, ID аккаунта, например, 123123
 - `selectel_user_admin_user`, сервисный пользователь с нужными правами 
 - `selectel_user_admin_password`, пароль от сервисного пользователя
 
-Если их не указать в переменных окружения или в команде `terraform plan/apply` с помощью параметра `-var`, то будет предложено ввести значения данных переменных с клавиатуры.
+Переменные можно задать несколькими способами:
 
-Пример команды для запуска `terraform plan/apply` с указанием переменных окружения перед командой:
+- В качестве переменных окружения (для этого нужно добавить перед названием переменной `TF_VAR_`):
 
 ```bash
-TF_VAR_selectel_domain_name=<Selectel аккаунт ID> \
-TF_VAR_selectel_user_admin_user=<Имя сервисного пользователя с нужными правами> \
-TF_VAR_selectel_user_admin_password=<Пароль от сервисного пользователя> \
+export TF_VAR_selectel_domain_name=123123
+export TF_VAR_selectel_user_admin_user=foo
+export TF_VAR_selectel_user_admin_password=bar
 terraform plan/apply
 ```
+- Ввести вместе с командой `terraform plan/apply` с помощью параметра `-var`:
+
+```bash
+terraform plan/apply \
+-var="selectel_domain_name=123123" \
+-var="selectel_user_admin_user=foo" \
+-var="selectel_user_admin_password=bar"
+```
+
+- Ввести с клавиатуры, если переменные не были заданы любым другим способом
 
 После успешного выполнения команды `terraform apply` вы должны увидеть в своём аккаунте новый проект, в котором будет запущены все модули (MKS, SFS, vm, CRaaS и др.)
 
@@ -70,18 +82,19 @@ terraform plan/apply
   * [flavor](modules/flavor) - создание flavor (тип инстанса)
   * [floatingip](modules/floatingip) - создание плавающего ip адреса
   * [image_datasource](modules/image_datasource) - считывание айдишника образа
-  * [keypair](modules/keypair) - создание ключевой пары для подключения по ssh
+  * [keypair](modules/keypair) - создание ключевой пары для подключения по SSH
   * [mks](modules/mks) - набор модулей для создания [Selectel Managed Kubernetes](https://selectel.ru/services/cloud/kubernetes/)
     * [k8s-cluster](modules/mks/k8s-cluster) - создание master ноды k8s
     * [k8s-cluster-standalone](modules/mks/k8s-cluster-standalone) - создание managed kubernetes кластера
     * [k8s-nodegroup](modules/mks/k8s-nodegroup) - создание compute ноды k8s
-    * [k8s-nodegroup-gpu](modules/mks/k8s-nodegroup-gpu) - создание compute ноды с gpu k8s
-  * [nat](modules/nat) - создание nat сет
-  * [os_project_with_user](modules/os_project_with_user) - создание проекта в облаке selectel
+    * [k8s-nodegroup-gpu](modules/mks/k8s-nodegroup-gpu) - создание compute ноды с GPU k8s
+  * [nat](modules/nat) - создание nat сети
+  * [network](modules/network) - создание локальной сети
+  * [os_project_with_user](modules/os_project_with_user) - создание проекта в облаке Selectel
   * [s3](modules/s3) - создание [объектного хранилища s3](https://selectel.ru/services/cloud/storage/)
     * [s3](modules/s3-bucket) - создание s3 бакета
     * [s3](modules/s3-credentioals) - создание s3 параметров авторизации
-  * [selectel-token](modules/selectel) - создание токена аккаунта selectel
+  * [selectel-token](modules/selectel) - создание токена аккаунта Selectel
   * [sfs](modules/sfs) - создание [файлового хранилища](https://selectel.ru/lab/file-storage/)
   * [vm](modules/vm) - создание [виртуального облачного сервера](https://selectel.ru/services/cloud/servers/)
   * [volume](modules/volume) - создание облачного диска

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Test Selectel Terraform modules](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml)
 
-Перед началом работы с облачными ресурсами Selectel через Terraform рекомендуем ознакомиться с [документацией по провайдеру Selectel/OpenStack](https://docs.selectel.ru/terraform/). В [данном репозитории](https://github.com/selectel/selectel-infra-examples) находятся примеры Terraform модулей, используемых для создания инфраструктуры в облаке Selectel.
+Перед началом работы с облачными ресурсами Selectel через Terraform рекомендуем ознакомиться с [документацией по провайдеру Selectel/OpenStack](https://docs.selectel.ru/terraform/). 
+
+В [данном репозитории](https://github.com/selectel/selectel-infra-examples) находятся примеры Terraform модулей, используемых для создания инфраструктуры в облаке Selectel.
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ module "mks" {
   source = "./modules/mks/k8s-cluster-standalone"
 
   cluster_name = "gh-cluster-test"
-  kube_version = "1.28.3" # Здесь важно выбрать доступную версию, может протухнуть
+  kube_version = "1.29.1" # Здесь важно выбрать доступную версию, может протухнуть
 
   os_availability_zone = "ru-9a"
   os_region            = "ru-9"

--- a/modules/mks/k8s-cluster-standalone/README.md
+++ b/modules/mks/k8s-cluster-standalone/README.md
@@ -9,7 +9,7 @@
 ## Providers
 
 | Name | Version |
-|------|---------|network_1
+|------|---------|
 | <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >= 4.0.2 |
 
 ## Modules

--- a/modules/mks/k8s-cluster-standalone/README.md
+++ b/modules/mks/k8s-cluster-standalone/README.md
@@ -9,7 +9,7 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+|------|---------|network_1
 | <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >= 4.0.2 |
 
 ## Modules
@@ -55,6 +55,7 @@
 | <a name="input_ng_taints"></a> [ng\_taints](#input\_ng\_taints) | n/a | <pre>list(object({<br>    key    = string<br>    value  = string<br>    effect = string<br>  }))</pre> | `[]` | no |
 | <a name="input_ng_volume_gb"></a> [ng\_volume\_gb](#input\_ng\_volume\_gb) | n/a | `list(number)` | <pre>[<br>  32<br>]</pre> | no |
 | <a name="input_ng_volume_type"></a> [ng\_volume\_type](#input\_ng\_volume\_type) | n/a | `list(string)` | <pre>[<br>  "fast"<br>]</pre> | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | Sets whether a network should have a gateway | `string` | `false` | no |
 | <a name="input_nodegroups"></a> [nodegroups](#input\_nodegroups) | n/a | `string` | `1` | no |
 | <a name="input_os_auth_url"></a> [os\_auth\_url](#input\_os\_auth\_url) | n/a | `string` | `"https://api.selvpc.ru/identity/v3/auth/"` | no |
 | <a name="input_os_availability_zone"></a> [os\_availability\_zone](#input\_os\_availability\_zone) | n/a | `string` | n/a | yes |

--- a/modules/mks/k8s-cluster-standalone/vars.tf
+++ b/modules/mks/k8s-cluster-standalone/vars.tf
@@ -162,6 +162,7 @@ variable "gpu_ng_taints" {
 }
 
 variable "no_gateway" {
+  description = "Sets whether a network should have a gateway"
   type    = string
   default = false
 }

--- a/modules/mks/k8s-cluster-standalone/vars.tf
+++ b/modules/mks/k8s-cluster-standalone/vars.tf
@@ -163,6 +163,6 @@ variable "gpu_ng_taints" {
 
 variable "no_gateway" {
   description = "Sets whether a network should have a gateway"
-  type    = string
-  default = false
+  type        = string
+  default     = false
 }

--- a/modules/nat/README.md
+++ b/modules/nat/README.md
@@ -32,6 +32,7 @@ No modules.
 | <a name="input_dns_nameservers"></a> [dns\_nameservers](#input\_dns\_nameservers) | DNS servers to be used | `list(string)` | <pre>[<br>  "188.93.16.19",<br>  "188.93.17.19"<br>]</pre> | no |
 | <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp) | DHCP enable flag | `bool` | `false` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"` | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | (Optional) Do not set a gateway IP on this subnet. Changing this removes or adds a default gateway IP of the existing subnet. | `bool` | `true` | no |
 | <a name="input_router_external_net_name"></a> [router\_external\_net\_name](#input\_router\_external\_net\_name) | Name of external network to be used | `string` | `"external-network"` | no |
 | <a name="input_router_name"></a> [router\_name](#input\_router\_name) | Router name to be created | `string` | `"router_1"` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Subnet CIRD to be created | `string` | `"192.168.0.0/24"` | no |

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -1,0 +1,39 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 1.53.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_openstack"></a> [openstack](#provider\_openstack) | 1.53.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [openstack_networking_network_v2.network_1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_network_v2) | resource |
+| [openstack_networking_subnet_v2.subnet_1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_subnet_v2) | resource |
+
+## Inputs
+
+| Name                                                                     | Description | Type | Default            | Required |
+|--------------------------------------------------------------------------|-------------|------|--------------------|:--------:|
+| <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp)    | DHCP enable flag | `bool` | `false`            | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway)       | Sets whether a network should have a gateway | `string` | `"true"`           | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"`      | no |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr)    | Subnet CIRD to be created | `string` | `"192.168.0.0/24"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID созданной сети |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | ID созданной подсети |

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -24,16 +24,16 @@ No modules.
 
 ## Inputs
 
-| Name                                                                     | Description | Type | Default            | Required |
-|--------------------------------------------------------------------------|-------------|------|--------------------|:--------:|
-| <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp)    | DHCP enable flag | `bool` | `false`            | no |
-| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway)       | Sets whether a network should have a gateway | `string` | `"true"`           | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"`      | no |
-| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr)    | Subnet CIRD to be created | `string` | `"192.168.0.0/24"` | no |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp) | n/a | `bool` | `false` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | n/a | `string` | `"network_1"` | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | Sets whether a network should have a gateway | `string` | `true` | no |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | n/a | `string` | `"192.168.0.0/24"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID созданной сети |
-| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | ID созданной подсети |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | n/a |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |

--- a/modules/network/vars.tf
+++ b/modules/network/vars.tf
@@ -11,5 +11,7 @@ variable "enable_dhcp" {
 }
 
 variable "no_gateway" {
-  default = true
+  description = "Sets whether a network should have a gateway"
+  type        = string
+  default     = true
 }

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -43,6 +43,7 @@
 | <a name="input_local_network_2_name"></a> [local\_network\_2\_name](#input\_local\_network\_2\_name) | Local network name to be created | `string` | `"local_network_2"` | no |
 | <a name="input_local_network_2_subnet_cidr"></a> [local\_network\_2\_subnet\_cidr](#input\_local\_network\_2\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.2.0/24"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"` | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | Sets whether a network should have a gateway | `string` | `"false"` | no |
 | <a name="input_os_region"></a> [os\_region](#input\_os\_region) | Region where network will be created | `string` | n/a | yes |
 | <a name="input_os_zone"></a> [os\_zone](#input\_os\_zone) | OS zone to be used | `string` | n/a | yes |
 | <a name="input_router_external_net_name"></a> [router\_external\_net\_name](#input\_router\_external\_net\_name) | Name of external network to be used | `string` | `"external-network"` | no |

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -17,7 +17,8 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_nat"></a> [nat](#module\_nat) | ../nat | n/a |
-| <a name="module_network"></a> [network](#module\_network) | ../network | n/a |
+| <a name="module_network_1"></a> [network\_1](#module\_network\_1) | ../network | n/a |
+| <a name="module_network_2"></a> [network\_2](#module\_network\_2) | ../network | n/a |
 | <a name="module_os-flavor"></a> [os-flavor](#module\_os-flavor) | ../flavor | n/a |
 | <a name="module_volume"></a> [volume](#module\_volume) | ../volume | n/a |
 
@@ -43,14 +44,14 @@
 | <a name="input_local_network_2_name"></a> [local\_network\_2\_name](#input\_local\_network\_2\_name) | Local network name to be created | `string` | `"local_network_2"` | no |
 | <a name="input_local_network_2_subnet_cidr"></a> [local\_network\_2\_subnet\_cidr](#input\_local\_network\_2\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.2.0/24"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"` | no |
-| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | Sets whether a network should have a gateway | `string` | `"false"` | no |
+| <a name="input_no_gateway"></a> [no\_gateway](#input\_no\_gateway) | Sets whether a network should have a gateway | `string` | `false` | no |
 | <a name="input_os_region"></a> [os\_region](#input\_os\_region) | Region where network will be created | `string` | n/a | yes |
 | <a name="input_os_zone"></a> [os\_zone](#input\_os\_zone) | OS zone to be used | `string` | n/a | yes |
 | <a name="input_router_external_net_name"></a> [router\_external\_net\_name](#input\_router\_external\_net\_name) | Name of external network to be used | `string` | `"external-network"` | no |
 | <a name="input_router_name"></a> [router\_name](#input\_router\_name) | Router name to be created | `string` | `"router_1"` | no |
 | <a name="input_server_root_disk_gb"></a> [server\_root\_disk\_gb](#input\_server\_root\_disk\_gb) | List of disks | `list(number)` | <pre>[<br>  40<br>]</pre> | no |
 | <a name="input_server_volume_type"></a> [server\_volume\_type](#input\_server\_volume\_type) | List of disk types | `list(string)` | <pre>[<br>  "fast"<br>]</pre> | no |
-| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Subnet CIRD to be created | `string` | `"192.168.0.0/24"` | no |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.0.0/24"` | no |
 | <a name="input_vm_local_disk_gb"></a> [vm\_local\_disk\_gb](#input\_vm\_local\_disk\_gb) | Flavor's local disk size | `string` | `"0"` | no |
 | <a name="input_vm_name"></a> [vm\_name](#input\_vm\_name) | Name of VM to create | `string` | n/a | yes |
 | <a name="input_vm_ram_mb"></a> [vm\_ram\_mb](#input\_vm\_ram\_mb) | RAM in VMs flavor | `number` | `4096` | no |

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -38,10 +38,10 @@
 | <a name="input_dns_nameservers"></a> [dns\_nameservers](#input\_dns\_nameservers) | DNS servers to be used, selectel dns is default | `list(string)` | <pre>[<br>  "188.93.16.19",<br>  "188.93.17.19"<br>]</pre> | no |
 | <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp) | DHCP enable flag | `bool` | `false` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | n/a | `list(string)` | <pre>[<br>  "Ubuntu 20.04 LTS 64-bit"<br>]</pre> | no |
-| <a name="input_local_network_1_name"></a> [local\_network\_1\_name](#local\_network\_1\_name) | Local network name to be created | `string` | `"local_network_1"` | no |
-| <a name="input_local_network_1_subnet_cidr"></a> [local\_network\_1\_subnet\_cidr](#local\_network\_1\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.1.0/24"` | no |
-| <a name="input_local_network_2_name"></a> [local\_network\_2\_name](#local\_network\_2\_name) | Local network name to be created | `string` | `"local_network_2"` | no |
-| <a name="input_local_network_2_subnet_cidr"></a> [local\_network\_2\_subnet\_cidr](#local\_network\_2\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.2.0/24"` | no |
+| <a name="input_local_network_1_name"></a> [local\_network\_1\_name](#input\_local\_network\_1\_name) | Local network name to be created | `string` | `"local_network_1"` | no |
+| <a name="input_local_network_1_subnet_cidr"></a> [local\_network\_1\_subnet\_cidr](#input\_local\_network\_1\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.1.0/24"` | no |
+| <a name="input_local_network_2_name"></a> [local\_network\_2\_name](#input\_local\_network\_2\_name) | Local network name to be created | `string` | `"local_network_2"` | no |
+| <a name="input_local_network_2_subnet_cidr"></a> [local\_network\_2\_subnet\_cidr](#input\_local\_network\_2\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.2.0/24"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"` | no |
 | <a name="input_os_region"></a> [os\_region](#input\_os\_region) | Region where network will be created | `string` | n/a | yes |
 | <a name="input_os_zone"></a> [os\_zone](#input\_os\_zone) | OS zone to be used | `string` | n/a | yes |

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -17,6 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_nat"></a> [nat](#module\_nat) | ../nat | n/a |
+| <a name="module_network"></a> [network](#module\_network) | ../network | n/a |
 | <a name="module_os-flavor"></a> [os-flavor](#module\_os-flavor) | ../flavor | n/a |
 | <a name="module_volume"></a> [volume](#module\_volume) | ../volume | n/a |
 
@@ -25,7 +26,10 @@
 | Name | Type |
 |------|------|
 | [openstack_compute_instance_v2.instance_1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/compute_instance_v2) | resource |
+| [openstack_compute_interface_attach_v2.port_3_attach](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/compute_interface_attach_v2) | resource |
 | [openstack_networking_port_v2.port_1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_port_v2) | resource |
+| [openstack_networking_port_v2.port_2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_port_v2) | resource |
+| [openstack_networking_port_v2.port_3](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_port_v2) | resource |
 
 ## Inputs
 
@@ -34,6 +38,10 @@
 | <a name="input_dns_nameservers"></a> [dns\_nameservers](#input\_dns\_nameservers) | DNS servers to be used, selectel dns is default | `list(string)` | <pre>[<br>  "188.93.16.19",<br>  "188.93.17.19"<br>]</pre> | no |
 | <a name="input_enable_dhcp"></a> [enable\_dhcp](#input\_enable\_dhcp) | DHCP enable flag | `bool` | `false` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | n/a | `list(string)` | <pre>[<br>  "Ubuntu 20.04 LTS 64-bit"<br>]</pre> | no |
+| <a name="input_local_network_1_name"></a> [local\_network\_1\_name](#local\_network\_1\_name) | Local network name to be created | `string` | `"local_network_1"` | no |
+| <a name="input_local_network_1_subnet_cidr"></a> [local\_network\_1\_subnet\_cidr](#local\_network\_1\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.1.0/24"` | no |
+| <a name="input_local_network_2_name"></a> [local\_network\_2\_name](#local\_network\_2\_name) | Local network name to be created | `string` | `"local_network_2"` | no |
+| <a name="input_local_network_2_subnet_cidr"></a> [local\_network\_2\_subnet\_cidr](#local\_network\_2\_subnet\_cidr) | Subnet CIDR to be created | `string` | `"192.168.2.0/24"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Network name to be created | `string` | `"network_1"` | no |
 | <a name="input_os_region"></a> [os\_region](#input\_os\_region) | Region where network will be created | `string` | n/a | yes |
 | <a name="input_os_zone"></a> [os\_zone](#input\_os\_zone) | OS zone to be used | `string` | n/a | yes |

--- a/modules/vm/vars.tf
+++ b/modules/vm/vars.tf
@@ -113,6 +113,7 @@ variable "enable_dhcp" {
 }
 
 variable "no_gateway" {
+  description = "Sets whether a network should have a gateway"
   type    = string
   default = false
 }

--- a/modules/vm/vars.tf
+++ b/modules/vm/vars.tf
@@ -114,6 +114,6 @@ variable "enable_dhcp" {
 
 variable "no_gateway" {
   description = "Sets whether a network should have a gateway"
-  type    = string
-  default = false
+  type        = string
+  default     = false
 }


### PR DESCRIPTION
- Обновлён корневой README.md, добавлены примеры для разных способов указания переменных для Terraform.
- Для модулей, затронутых прошлым пулл реквестом, перегенерированы README.
- Пайплайн изменён так, чтобы он запускался по расписанию только на основной ветке. Руками по-прежнему гонится где угодно.