### PR TITLE
Перенос tf-state в S3 & Обновление версии tf-selectel-provider

### DIFF
--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,12 +28,11 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
-        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,7 +28,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoints=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -30,7 +30,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -11,7 +11,6 @@ jobs:
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
-      terraform_remote_state_address: ${{ secrets.GITLAB_STATE_ADDRESS }}
 
     steps:
     - name: Checkout the repo
@@ -27,14 +26,14 @@ jobs:
 
     - name: Init Terraform
       run: >
-        terraform init -reconfigure \
-        -backend-config="bucket=github-terraform-state" \
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru" \
-        -backend-config="key=github-infra-examples.tfstate" \
-        -backend-config="region=ru-1" \
-        -backend-config="skip_region_validation=true" \
-        -backend-config="skip_credentials_validation=true" \
-        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}" \
+        terraform init -reconfigure
+        -backend-config="bucket=github-terraform-state"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="key=github-infra-examples.tfstate"
+        -backend-config="region=ru-1"
+        -backend-config="skip_region_validation=true"
+        -backend-config="skip_credentials_validation=true"
+        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 
     - name: Terraform destroy

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -35,7 +35,6 @@ jobs:
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
-        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -34,6 +34,8 @@ jobs:
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
         -backend-config="skip_requesting_account_id=true"
+        -backend-config="force_path_style=true"
+        -backend-config="skip_metadata_api_check=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,7 +28,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -33,6 +33,7 @@ jobs:
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
+        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -27,15 +27,15 @@ jobs:
 
     - name: Init Terraform
       run: >
-        terraform init -reconfigure
-        -backend-config="address=$terraform_remote_state_address"
-        -backend-config="lock_address=$terraform_remote_state_address/lock" 
-        -backend-config="unlock_address=$terraform_remote_state_address/lock"
-        -backend-config="username=${{ secrets.GITLAB_STATE_USERNAME }}"
-        -backend-config="password=${{ secrets.GITLAB_STATE_TOKEN }}"
-        -backend-config="lock_method=POST"
-        -backend-config="unlock_method=DELETE"
-        -backend-config="retry_wait_min=5"
+        terraform init -reconfigure \
+        -backend-config="bucket=github-terraform-state" \
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru" \
+        -backend-config="key=github-infra-examples.tfstate" \
+        -backend-config="region=ru-1" \
+        -backend-config="skip_region_validation=true" \
+        -backend-config="skip_credentials_validation=true" \
+        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}" \
+        -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 
     - name: Terraform destroy
       run: terraform destroy -auto-approve

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,7 +28,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,10 +28,12 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
+        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
+        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -28,7 +28,6 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3.0.0
+      with:
+        terraform_version: "1.5.7"
 
     - name: Init Terraform
       run: >
@@ -34,8 +36,6 @@ jobs:
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
         -backend-config="skip_requesting_account_id=true"
-        -backend-config="force_path_style=true"
-        -backend-config="skip_metadata_api_check=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -13,7 +13,6 @@ jobs:
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
-      terraform_remote_state_address: ${{ secrets.GITLAB_STATE_ADDRESS }}
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
 
     steps:
@@ -42,14 +41,14 @@ jobs:
 
     - name: Init Terraform
       run: >
-        terraform init -reconfigure \
-        -backend-config="bucket=github-terraform-state" \
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru" \
-        -backend-config="key=github-infra-examples.tfstate" \
-        -backend-config="region=ru-1" \
-        -backend-config="skip_region_validation=true" \
-        -backend-config="skip_credentials_validation=true" \
-        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}" \
+        terraform init -reconfigure
+        -backend-config="bucket=github-terraform-state"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="key=github-infra-examples.tfstate"
+        -backend-config="region=ru-1"
+        -backend-config="skip_region_validation=true"
+        -backend-config="skip_credentials_validation=true"
+        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 
     - name: Terraform apply

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -44,7 +44,7 @@ jobs:
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
         -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
-        -backend-config="key=github-infra-examples.tfstate"
+        -backend-config="key=github-infra-examples.json"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,10 +43,12 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
+        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
+        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,7 +43,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -48,6 +48,7 @@ jobs:
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
+        -backend-config="skip_requesting_account_id=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -45,7 +45,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -59,17 +59,17 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-#    - name: Telegram notify if job was failed
-#      if: ${{ failure() }}
-#      uses: appleboy/telegram-action@master
-#      with:
-#        to: ${{ secrets.TELEGRAM_TO }}
-#        token: ${{ secrets.TELEGRAM_TOKEN }}
-#        message: |
-#          -= GITHUB public repository selectel/selectel-infra-examples =-
-#          Terraform modules build pipeline was failed
-#          🚨 Critical
-#          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
-#
-#          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-#          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+    - name: Telegram notify if job was failed
+      if: ${{ failure() }}
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        message: |
+          -= GITHUB public repository selectel/selectel-infra-examples =-
+          Terraform modules build pipeline was failed
+          🚨 Critical
+          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
+
+          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -44,13 +44,10 @@ jobs:
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
         -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
-        -backend-config="key=github-infra-examples.json"
+        -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
-        -backend-config="skip_requesting_account_id=true"
-        -backend-config="force_path_style=true"
-        -backend-config="skip_metadata_api_check=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -42,15 +42,15 @@ jobs:
 
     - name: Init Terraform
       run: >
-        terraform init -reconfigure
-        -backend-config="address=$terraform_remote_state_address"
-        -backend-config="lock_address=$terraform_remote_state_address/lock" 
-        -backend-config="unlock_address=$terraform_remote_state_address/lock"
-        -backend-config="username=${{ secrets.GITLAB_STATE_USERNAME }}"
-        -backend-config="password=${{ secrets.GITLAB_STATE_TOKEN }}"
-        -backend-config="lock_method=POST"
-        -backend-config="unlock_method=DELETE"
-        -backend-config="retry_wait_min=5"
+        terraform init -reconfigure \
+        -backend-config="bucket=github-terraform-state" \
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru" \
+        -backend-config="key=github-infra-examples.tfstate" \
+        -backend-config="region=ru-1" \
+        -backend-config="skip_region_validation=true" \
+        -backend-config="skip_credentials_validation=true" \
+        -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}" \
+        -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 
     - name: Terraform apply
       run: terraform apply -auto-approve

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3.0.0
+      with:
+        terraform_version: "1.5.7"
 
 #    - name: Run Checkov action # suppressed for now because it fails to copy a file inside a self-hosted runner
 #      uses: bridgecrewio/checkov-action@v12
@@ -48,9 +50,6 @@ jobs:
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
-        -backend-config="skip_requesting_account_id=true"
-        -backend-config="force_path_style=true"
-        -backend-config="skip_metadata_api_check=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,7 +43,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,12 +43,13 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoint=https://s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
         -backend-config="skip_requesting_account_id=true"
+        -backend-config="force_path_style=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 
@@ -58,17 +59,17 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-    - name: Telegram notify if job was failed
-      if: ${{ failure() }}
-      uses: appleboy/telegram-action@master
-      with:
-        to: ${{ secrets.TELEGRAM_TO }}
-        token: ${{ secrets.TELEGRAM_TOKEN }}
-        message: |
-          -= GITHUB public repository selectel/selectel-infra-examples =-
-          Terraform modules build pipeline was failed
-          🚨 Critical
-          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
-
-          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+#    - name: Telegram notify if job was failed
+#      if: ${{ failure() }}
+#      uses: appleboy/telegram-action@master
+#      with:
+#        to: ${{ secrets.TELEGRAM_TO }}
+#        token: ${{ secrets.TELEGRAM_TOKEN }}
+#        message: |
+#          -= GITHUB public repository selectel/selectel-infra-examples =-
+#          Terraform modules build pipeline was failed
+#          🚨 Critical
+#          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
+#
+#          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,7 +43,6 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -49,6 +49,8 @@ jobs:
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
         -backend-config="skip_requesting_account_id=true"
+        -backend-config="force_path_style=true"
+        -backend-config="skip_metadata_api_check=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -49,7 +49,6 @@ jobs:
         -backend-config="skip_region_validation=true"
         -backend-config="skip_credentials_validation=true"
         -backend-config="skip_requesting_account_id=true"
-        -backend-config="force_path_style=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -43,7 +43,7 @@ jobs:
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoints.s3=s3.ru-1.storage.selcloud.ru"
+        -backend-config="endpoints=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="region=ru-1"
         -backend-config="skip_region_validation=true"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@
 
 ## Usage
 
-1. Инициализировать Terraform Backend
+1. Перед использованием проверьте версию Terraform, данный репозиторий имеет ограничение на использование, по-причине хранения стейта в S3.
+
+```bash
+terraform {
+  backend "s3" {}
+  required_version = ">= 1.0.0, <= 1.5.7"
+}
+```
+
+подробнее о проблеме можно ознакомиться на офф. странице [тут](https://developer.hashicorp.com/terraform/language/upgrade-guides). 
+
+2. Инициализировать Terraform Backend
 
 ```bash
 terraform init
 ```
 
-2. Создать файл `main.tf`, где описана необходимая инфраструктура (пример ниже - создание `Simple File Storage`)
+3. Создать файл `main.tf`, где описана необходимая инфраструктура (пример ниже - создание `Simple File Storage`)
 
 ```yaml
 module "sfs" {
@@ -27,7 +38,7 @@ module "sfs" {
 }
 ```
 
-3. Для проверки и применения настроек необходимо запустить команды `terraform plan/apply`
+4. Для проверки и применения настроек необходимо запустить команды `terraform plan/apply`
 
 
 ```bash

--- a/README_TF.md
+++ b/README_TF.md
@@ -1,0 +1,47 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 1.53.0 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.1.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_openstack"></a> [openstack](#provider\_openstack) | 1.53.0 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.1.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_craas"></a> [craas](#module\_craas) | ./modules/craas | n/a |
+| <a name="module_fl_ip"></a> [fl\_ip](#module\_fl\_ip) | ./modules/floatingip | n/a |
+| <a name="module_mks"></a> [mks](#module\_mks) | ./modules/mks/k8s-cluster-standalone | n/a |
+| <a name="module_project-with-user"></a> [project-with-user](#module\_project-with-user) | ./modules/os_project_with_user | n/a |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | ./modules/s3/s3-bucket | n/a |
+| <a name="module_s3-creds"></a> [s3-creds](#module\_s3-creds) | ./modules/s3/s3-credentials | n/a |
+| <a name="module_sfs"></a> [sfs](#module\_sfs) | ./modules/sfs | n/a |
+| <a name="module_vm"></a> [vm](#module\_vm) | ./modules/vm | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [openstack_networking_floatingip_associate_v2.association_1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.53.0/docs/resources/networking_floatingip_associate_v2) | resource |
+| [selectel_mks_kube_versions_v1.versions](https://registry.terraform.io/providers/selectel/selectel/5.1.1/docs/data-sources/mks_kube_versions_v1) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_os_auth_url"></a> [os\_auth\_url](#input\_os\_auth\_url) | URL до openstack api | `string` | `"https://cloud.api.selcloud.ru/identity/v3"` | no |
+| <a name="input_selectel_domain_name"></a> [selectel\_domain\_name](#input\_selectel\_domain\_name) | ID Selectel аккаунта | `string` | n/a | yes |
+| <a name="input_selectel_user_admin_password"></a> [selectel\_user\_admin\_password](#input\_selectel\_user\_admin\_password) | Пароль от сервисного пользователя | `string` | n/a | yes |
+| <a name="input_selectel_user_admin_user"></a> [selectel\_user\_admin\_user](#input\_selectel\_user\_admin\_user) | Имя сервисного пользователя, необходимо создать через панель my.selectel | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/README_TF.md
+++ b/README_TF.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | '>= 1.0.0, <= 1.5.7' |
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 1.53.0 |
 | <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.1.1 |
 

--- a/main.tf
+++ b/main.tf
@@ -6,136 +6,136 @@ module "project-with-user" {
   os_project_name = "gh_test_tf_modules"
   os_username     = "gh_test_tf_user"
 }
-#
-# # Создаём виртуалку и всё, что необходимо для её работы
-# module "vm" {
-#   source              = "./modules/vm"
-#   os_region           = "ru-9"
-#   os_zone             = "ru-9a"
-#   vm_name             = "github-vm"
-#   server_root_disk_gb = ["10"]
-#   vm_vcpus            = 4
-#   vm_ram_mb           = 4096
-#   enable_dhcp         = true
-#
-#   depends_on = [
-#     module.project-with-user
-#   ]
-# }
-#
-# # Создаём simple file storage в той же сети, где находится виртуальная машина
-# module "sfs" {
-#   source               = "./modules/sfs"
-#   os_availability_zone = "ru-9a"
-#   sfs_size             = 70
-#   sfs_volume_type      = "basic"
-#   os_network_id        = module.vm.nat_net_id
-#   os_subnet_id         = module.vm.nat_sub_id
-#
-#   depends_on = [
-#     module.vm
-#   ]
-# }
-#
-# # S3 нет в провайдере Selectel, поэтому под капотом terracurl
-#
-# # Создаём S3-ключ для пользователя
-# module "s3-creds" {
-#   source           = "./modules/s3/s3-credentials"
-#   os_user_id       = module.project-with-user.user_id
-#   os_project_id    = module.project-with-user.project_id
-#   credentials_name = "github-s3-creds"
-#
-#   depends_on = [
-#     module.project-with-user
-#   ]
-# }
-#
-# # Создаём S3-bucket
-# module "s3-bucket" {
-#   source          = "./modules/s3/s3-bucket"
-#   os_account      = var.selectel_domain_name
-#   os_username     = module.project-with-user.user_name
-#   os_password     = module.project-with-user.user_password
-#   os_project_id   = module.project-with-user.project_id
-#   os_project_name = module.project-with-user.project_name
-#   s3_bucket_name  = "github-s3-bucket"
-#
-#   depends_on = [
-#     module.project-with-user
-#   ]
-# }
-#
-# # Создаём CRaaS
-# module "craas" {
-#   source        = "./modules/craas"
-#   os_project_id = module.project-with-user.project_id
-#   token_ttl     = "1y"
-#
-#   depends_on = [
-#     module.project-with-user
-#   ]
-# }
-#
-# # Аттачим floating IP к виртуалке
-#
-# # Создаём floating IP
-# module "fl_ip" {
-#   source = "./modules/floatingip"
-#   region = "ru-9"
-#
-#   depends_on = [
-#     module.vm
-#   ]
-# }
-#
-# resource "openstack_networking_floatingip_associate_v2" "association_1" {
-#   port_id     = module.vm.vm_port_id
-#   floating_ip = module.fl_ip.floatingip_address
-#   region      = "ru-9"
-#
-#   depends_on = [
-#     module.fl_ip
-#   ]
-# }
-#
-# # Запрашиваем данные, из которых позже возьмём последнюю версию K8s
-# data "selectel_mks_kube_versions_v1" "versions" {
-#   project_id = module.project-with-user.project_id
-#   region     = "ru-9"
-# }
-#
-# # Создаём MKS с CPU и GPU нод-группами
-# module "mks" {
-#   source = "./modules/mks/k8s-cluster-standalone"
-#
-#   cluster_name = "gh-cluster-test"
-#   kube_version = data.selectel_mks_kube_versions_v1.versions.latest_version
-#
-#   os_availability_zone = "ru-9a"
-#   os_region            = "ru-9"
-#   os_project_id        = module.project-with-user.project_id
-#
-#   nodegroups     = 1
-#   ng_nodes_count = [1]
-#   ng_cpus        = [4]
-#   ng_ram_mb      = [8192]
-#   ng_volume_gb   = [100]
-#   ng_volume_type = ["fast"]
-#   ng_labels      = [{ "role" : "cpu" }]
-#
-#   gpu_nodegroups     = 1
-#   gpu_ng_nodes_count = [1]
-#   gpu_ng_volume_gb   = [100]
-#   gpu_ng_volume_type = ["fast"]
-#   gpu_ng_labels      = [{ "role" : "gpu" }]
-#   gpu_ng_flavor      = ["3031"]
-#
-#   nat_subnet_cidr   = "10.222.0.0/16"
-#   enable_autorepair = false
-#   network_id        = ""
-#
-#   depends_on = [
-#     module.project-with-user
-#   ]
-# }
+
+# Создаём виртуалку и всё, что необходимо для её работы
+module "vm" {
+  source              = "./modules/vm"
+  os_region           = "ru-9"
+  os_zone             = "ru-9a"
+  vm_name             = "github-vm"
+  server_root_disk_gb = ["10"]
+  vm_vcpus            = 4
+  vm_ram_mb           = 4096
+  enable_dhcp         = true
+
+  depends_on = [
+    module.project-with-user
+  ]
+}
+
+# Создаём simple file storage в той же сети, где находится виртуальная машина
+module "sfs" {
+  source               = "./modules/sfs"
+  os_availability_zone = "ru-9a"
+  sfs_size             = 70
+  sfs_volume_type      = "basic"
+  os_network_id        = module.vm.nat_net_id
+  os_subnet_id         = module.vm.nat_sub_id
+
+  depends_on = [
+    module.vm
+  ]
+}
+
+# S3 нет в провайдере Selectel, поэтому под капотом terracurl
+
+# Создаём S3-ключ для пользователя
+module "s3-creds" {
+  source           = "./modules/s3/s3-credentials"
+  os_user_id       = module.project-with-user.user_id
+  os_project_id    = module.project-with-user.project_id
+  credentials_name = "github-s3-creds"
+
+  depends_on = [
+    module.project-with-user
+  ]
+}
+
+# Создаём S3-bucket
+module "s3-bucket" {
+  source          = "./modules/s3/s3-bucket"
+  os_account      = var.selectel_domain_name
+  os_username     = module.project-with-user.user_name
+  os_password     = module.project-with-user.user_password
+  os_project_id   = module.project-with-user.project_id
+  os_project_name = module.project-with-user.project_name
+  s3_bucket_name  = "github-s3-bucket"
+
+  depends_on = [
+    module.project-with-user
+  ]
+}
+
+# Создаём CRaaS
+module "craas" {
+  source        = "./modules/craas"
+  os_project_id = module.project-with-user.project_id
+  token_ttl     = "1y"
+
+  depends_on = [
+    module.project-with-user
+  ]
+}
+
+# Аттачим floating IP к виртуалке
+
+# Создаём floating IP
+module "fl_ip" {
+  source = "./modules/floatingip"
+  region = "ru-9"
+
+  depends_on = [
+    module.vm
+  ]
+}
+
+resource "openstack_networking_floatingip_associate_v2" "association_1" {
+  port_id     = module.vm.vm_port_id
+  floating_ip = module.fl_ip.floatingip_address
+  region      = "ru-9"
+
+  depends_on = [
+    module.fl_ip
+  ]
+}
+
+# Запрашиваем данные, из которых позже возьмём последнюю версию K8s
+data "selectel_mks_kube_versions_v1" "versions" {
+  project_id = module.project-with-user.project_id
+  region     = "ru-9"
+}
+
+# Создаём MKS с CPU и GPU нод-группами
+module "mks" {
+  source = "./modules/mks/k8s-cluster-standalone"
+
+  cluster_name = "gh-cluster-test"
+  kube_version = data.selectel_mks_kube_versions_v1.versions.latest_version
+
+  os_availability_zone = "ru-9a"
+  os_region            = "ru-9"
+  os_project_id        = module.project-with-user.project_id
+
+  nodegroups     = 1
+  ng_nodes_count = [1]
+  ng_cpus        = [4]
+  ng_ram_mb      = [8192]
+  ng_volume_gb   = [100]
+  ng_volume_type = ["fast"]
+  ng_labels      = [{ "role" : "cpu" }]
+
+  gpu_nodegroups     = 1
+  gpu_ng_nodes_count = [1]
+  gpu_ng_volume_gb   = [100]
+  gpu_ng_volume_type = ["fast"]
+  gpu_ng_labels      = [{ "role" : "gpu" }]
+  gpu_ng_flavor      = ["3031"]
+
+  nat_subnet_cidr   = "10.222.0.0/16"
+  enable_autorepair = false
+  network_id        = ""
+
+  depends_on = [
+    module.project-with-user
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -6,136 +6,136 @@ module "project-with-user" {
   os_project_name = "gh_test_tf_modules"
   os_username     = "gh_test_tf_user"
 }
-
-# Создаём виртуалку и всё, что необходимо для её работы
-module "vm" {
-  source              = "./modules/vm"
-  os_region           = "ru-9"
-  os_zone             = "ru-9a"
-  vm_name             = "github-vm"
-  server_root_disk_gb = ["10"]
-  vm_vcpus            = 4
-  vm_ram_mb           = 4096
-  enable_dhcp         = true
-
-  depends_on = [
-    module.project-with-user
-  ]
-}
-
-# Создаём simple file storage в той же сети, где находится виртуальная машина
-module "sfs" {
-  source               = "./modules/sfs"
-  os_availability_zone = "ru-9a"
-  sfs_size             = 70
-  sfs_volume_type      = "basic"
-  os_network_id        = module.vm.nat_net_id
-  os_subnet_id         = module.vm.nat_sub_id
-
-  depends_on = [
-    module.vm
-  ]
-}
-
-# S3 нет в провайдере Selectel, поэтому под капотом terracurl
-
-# Создаём S3-ключ для пользователя
-module "s3-creds" {
-  source           = "./modules/s3/s3-credentials"
-  os_user_id       = module.project-with-user.user_id
-  os_project_id    = module.project-with-user.project_id
-  credentials_name = "github-s3-creds"
-
-  depends_on = [
-    module.project-with-user
-  ]
-}
-
-# Создаём S3-bucket
-module "s3-bucket" {
-  source          = "./modules/s3/s3-bucket"
-  os_account      = var.selectel_domain_name
-  os_username     = module.project-with-user.user_name
-  os_password     = module.project-with-user.user_password
-  os_project_id   = module.project-with-user.project_id
-  os_project_name = module.project-with-user.project_name
-  s3_bucket_name  = "github-s3-bucket"
-
-  depends_on = [
-    module.project-with-user
-  ]
-}
-
-# Создаём CRaaS
-module "craas" {
-  source        = "./modules/craas"
-  os_project_id = module.project-with-user.project_id
-  token_ttl     = "1y"
-
-  depends_on = [
-    module.project-with-user
-  ]
-}
-
-# Аттачим floating IP к виртуалке
-
-# Создаём floating IP
-module "fl_ip" {
-  source = "./modules/floatingip"
-  region = "ru-9"
-
-  depends_on = [
-    module.vm
-  ]
-}
-
-resource "openstack_networking_floatingip_associate_v2" "association_1" {
-  port_id     = module.vm.vm_port_id
-  floating_ip = module.fl_ip.floatingip_address
-  region      = "ru-9"
-
-  depends_on = [
-    module.fl_ip
-  ]
-}
-
-# Запрашиваем данные, из которых позже возьмём последнюю версию K8s
-data "selectel_mks_kube_versions_v1" "versions" {
-  project_id = module.project-with-user.project_id
-  region     = "ru-9"
-}
-
-# Создаём MKS с CPU и GPU нод-группами
-module "mks" {
-  source = "./modules/mks/k8s-cluster-standalone"
-
-  cluster_name = "gh-cluster-test"
-  kube_version = data.selectel_mks_kube_versions_v1.versions.latest_version
-
-  os_availability_zone = "ru-9a"
-  os_region            = "ru-9"
-  os_project_id        = module.project-with-user.project_id
-
-  nodegroups     = 1
-  ng_nodes_count = [1]
-  ng_cpus        = [4]
-  ng_ram_mb      = [8192]
-  ng_volume_gb   = [100]
-  ng_volume_type = ["fast"]
-  ng_labels      = [{ "role" : "cpu" }]
-
-  gpu_nodegroups     = 1
-  gpu_ng_nodes_count = [1]
-  gpu_ng_volume_gb   = [100]
-  gpu_ng_volume_type = ["fast"]
-  gpu_ng_labels      = [{ "role" : "gpu" }]
-  gpu_ng_flavor      = ["3031"]
-
-  nat_subnet_cidr   = "10.222.0.0/16"
-  enable_autorepair = false
-  network_id        = ""
-
-  depends_on = [
-    module.project-with-user
-  ]
-}
+#
+# # Создаём виртуалку и всё, что необходимо для её работы
+# module "vm" {
+#   source              = "./modules/vm"
+#   os_region           = "ru-9"
+#   os_zone             = "ru-9a"
+#   vm_name             = "github-vm"
+#   server_root_disk_gb = ["10"]
+#   vm_vcpus            = 4
+#   vm_ram_mb           = 4096
+#   enable_dhcp         = true
+#
+#   depends_on = [
+#     module.project-with-user
+#   ]
+# }
+#
+# # Создаём simple file storage в той же сети, где находится виртуальная машина
+# module "sfs" {
+#   source               = "./modules/sfs"
+#   os_availability_zone = "ru-9a"
+#   sfs_size             = 70
+#   sfs_volume_type      = "basic"
+#   os_network_id        = module.vm.nat_net_id
+#   os_subnet_id         = module.vm.nat_sub_id
+#
+#   depends_on = [
+#     module.vm
+#   ]
+# }
+#
+# # S3 нет в провайдере Selectel, поэтому под капотом terracurl
+#
+# # Создаём S3-ключ для пользователя
+# module "s3-creds" {
+#   source           = "./modules/s3/s3-credentials"
+#   os_user_id       = module.project-with-user.user_id
+#   os_project_id    = module.project-with-user.project_id
+#   credentials_name = "github-s3-creds"
+#
+#   depends_on = [
+#     module.project-with-user
+#   ]
+# }
+#
+# # Создаём S3-bucket
+# module "s3-bucket" {
+#   source          = "./modules/s3/s3-bucket"
+#   os_account      = var.selectel_domain_name
+#   os_username     = module.project-with-user.user_name
+#   os_password     = module.project-with-user.user_password
+#   os_project_id   = module.project-with-user.project_id
+#   os_project_name = module.project-with-user.project_name
+#   s3_bucket_name  = "github-s3-bucket"
+#
+#   depends_on = [
+#     module.project-with-user
+#   ]
+# }
+#
+# # Создаём CRaaS
+# module "craas" {
+#   source        = "./modules/craas"
+#   os_project_id = module.project-with-user.project_id
+#   token_ttl     = "1y"
+#
+#   depends_on = [
+#     module.project-with-user
+#   ]
+# }
+#
+# # Аттачим floating IP к виртуалке
+#
+# # Создаём floating IP
+# module "fl_ip" {
+#   source = "./modules/floatingip"
+#   region = "ru-9"
+#
+#   depends_on = [
+#     module.vm
+#   ]
+# }
+#
+# resource "openstack_networking_floatingip_associate_v2" "association_1" {
+#   port_id     = module.vm.vm_port_id
+#   floating_ip = module.fl_ip.floatingip_address
+#   region      = "ru-9"
+#
+#   depends_on = [
+#     module.fl_ip
+#   ]
+# }
+#
+# # Запрашиваем данные, из которых позже возьмём последнюю версию K8s
+# data "selectel_mks_kube_versions_v1" "versions" {
+#   project_id = module.project-with-user.project_id
+#   region     = "ru-9"
+# }
+#
+# # Создаём MKS с CPU и GPU нод-группами
+# module "mks" {
+#   source = "./modules/mks/k8s-cluster-standalone"
+#
+#   cluster_name = "gh-cluster-test"
+#   kube_version = data.selectel_mks_kube_versions_v1.versions.latest_version
+#
+#   os_availability_zone = "ru-9a"
+#   os_region            = "ru-9"
+#   os_project_id        = module.project-with-user.project_id
+#
+#   nodegroups     = 1
+#   ng_nodes_count = [1]
+#   ng_cpus        = [4]
+#   ng_ram_mb      = [8192]
+#   ng_volume_gb   = [100]
+#   ng_volume_type = ["fast"]
+#   ng_labels      = [{ "role" : "cpu" }]
+#
+#   gpu_nodegroups     = 1
+#   gpu_ng_nodes_count = [1]
+#   gpu_ng_volume_gb   = [100]
+#   gpu_ng_volume_type = ["fast"]
+#   gpu_ng_labels      = [{ "role" : "gpu" }]
+#   gpu_ng_flavor      = ["3031"]
+#
+#   nat_subnet_cidr   = "10.222.0.0/16"
+#   enable_autorepair = false
+#   network_id        = ""
+#
+#   depends_on = [
+#     module.project-with-user
+#   ]
+# }

--- a/modules/craas/README.md
+++ b/modules/craas/README.md
@@ -2,13 +2,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -18,8 +18,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [selectel_craas_registry_v1.registry_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/craas_registry_v1) | resource |
-| [selectel_craas_token_v1.token_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/craas_token_v1) | resource |
+| [selectel_craas_registry_v1.registry_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/craas_registry_v1) | resource |
+| [selectel_craas_token_v1.token_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/craas_token_v1) | resource |
 
 ## Inputs
 

--- a/modules/craas/versions.tf
+++ b/modules/craas/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
   }
 }

--- a/modules/mks/k8s-cluster-standalone/README.md
+++ b/modules/mks/k8s-cluster-standalone/README.md
@@ -4,13 +4,13 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 1.53.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -25,7 +25,7 @@
 
 | Name | Type |
 |------|------|
-| [selectel_mks_kubeconfig_v1.kubeconfig](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/data-sources/mks_kubeconfig_v1) | data source |
+| [selectel_mks_kubeconfig_v1.kubeconfig](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_kubeconfig_v1) | data source |
 
 ## Inputs
 

--- a/modules/mks/k8s-cluster-standalone/versions.tf
+++ b/modules/mks/k8s-cluster-standalone/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"

--- a/modules/mks/k8s-cluster/README.md
+++ b/modules/mks/k8s-cluster/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -19,7 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [selectel_mks_cluster_v1.cluster_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/mks_cluster_v1) | resource |
+| [selectel_mks_cluster_v1.cluster_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/mks_cluster_v1) | resource |
 
 ## Inputs
 

--- a/modules/mks/k8s-cluster/versions.tf
+++ b/modules/mks/k8s-cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
   }
   required_version = ">= 1.5.0"

--- a/modules/mks/k8s-nodegroup-gpu/README.md
+++ b/modules/mks/k8s-nodegroup-gpu/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -19,7 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [selectel_mks_nodegroup_v1.nodegroup_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/mks_nodegroup_v1) | resource |
+| [selectel_mks_nodegroup_v1.nodegroup_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/mks_nodegroup_v1) | resource |
 
 ## Inputs
 

--- a/modules/mks/k8s-nodegroup-gpu/versions.tf
+++ b/modules/mks/k8s-nodegroup-gpu/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
   }
   required_version = ">= 1.5.0"

--- a/modules/mks/k8s-nodegroup/README.md
+++ b/modules/mks/k8s-nodegroup/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -19,7 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [selectel_mks_nodegroup_v1.nodegroup_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/mks_nodegroup_v1) | resource |
+| [selectel_mks_nodegroup_v1.nodegroup_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/mks_nodegroup_v1) | resource |
 
 ## Inputs
 

--- a/modules/mks/k8s-nodegroup/versions.tf
+++ b/modules/mks/k8s-nodegroup/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
   }
   required_version = ">= 1.5.0"

--- a/modules/os_project_with_user/README.md
+++ b/modules/os_project_with_user/README.md
@@ -4,14 +4,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -22,8 +22,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [random_password.serviceuser_1_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [selectel_iam_serviceuser_v1.serviceuser_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/iam_serviceuser_v1) | resource |
-| [selectel_vpc_project_v2.project_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/vpc_project_v2) | resource |
+| [selectel_iam_serviceuser_v1.serviceuser_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/iam_serviceuser_v1) | resource |
+| [selectel_vpc_project_v2.project_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) | resource |
 
 ## Inputs
 

--- a/modules/os_project_with_user/versions.tf
+++ b/modules/os_project_with_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/s3/s3-credentials/README.md
+++ b/modules/s3/s3-credentials/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 5.0.2 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | >=5.0.2 |
 
 ## Modules
 
@@ -19,7 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [selectel_iam_s3_credentials_v1.s3_credentials_1](https://registry.terraform.io/providers/selectel/selectel/5.0.2/docs/resources/iam_s3_credentials_v1) | resource |
+| [selectel_iam_s3_credentials_v1.s3_credentials_1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/iam_s3_credentials_v1) | resource |
 
 ## Inputs
 

--- a/modules/s3/s3-credentials/versions.tf
+++ b/modules/s3/s3-credentials/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 1.53.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 5.0.2 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | >=5.0.2 |
 
 ## Providers
 

--- a/modules/vm/versions.tf
+++ b/modules/vm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = ">=5.0.2"
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"

--- a/versions.tf
+++ b/versions.tf
@@ -9,8 +9,6 @@ terraform {
       version = "1.53.0"
     }
   }
-  backend "s3" {
-    endpoint = "s3.ru-1.storage.selcloud.ru"
-  }
+  backend "s3" {}
   required_version = ">= 1.0.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,5 +10,5 @@ terraform {
     }
   }
   backend "s3" {}
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0.0, <= 1.5.7"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,8 @@ terraform {
       version = "1.53.0"
     }
   }
-  backend "s3" {}
+  backend "s3" {
+    endpoint = "s3.ru-1.storage.selcloud.ru"
+  }
   required_version = ">= 1.0.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,13 +2,13 @@ terraform {
   required_providers {
     selectel = {
       source  = "selectel/selectel"
-      version = "5.0.2"
+      version = "5.1.1"
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"
       version = "1.53.0"
     }
   }
-  backend "http" {}
+  backend "s3" {}
   required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
- При переносе стейта в S3 оказалось, что в последней версии terraform 1.8.4 не работает non-AWS-s3 - подробнее [тут](https://developer.hashicorp.com/terraform/language/upgrade-guides)
- Зафиксировал версию 1.5.7 для terraform 
- Обновил до последней версии terraform-selectel-provider
- В модулях сделал условие на версии terraform-selectel-provider - ">= 5.0.2"
- В корневом versions.tf обновил terraform-selectel-provider до 5.1.1
- Обновил README.md файлы
 
Пайплайны зеленые
![Снимок экрана 2024-05-28 в 21 22 45](https://github.com/selectel/selectel-infra-examples/assets/11280073/111c29c9-1f90-49f8-aaa9-e1ede50020c4)
 