### PR TITLE
Изменение расписания запуска workflow для теста модулей

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -2,7 +2,7 @@ name: 'Test Selectel Terraform modules'
 
 on:
   schedule:
-    - cron: '0 7 * * *' # run every day at 10:00 MSK
+    - cron: '0 8 * * 2' # run every Tuesday at 11:00 MSK
   workflow_dispatch:
         
 jobs:
@@ -25,7 +25,7 @@ jobs:
         node-version: 20
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3.0.0
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: "1.5.5"
 

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -2,7 +2,7 @@ name: 'Test Opentofu Selectel Terraform modules'
 
 on:
   schedule:
-    - cron: '0 8 * * *' # run every day at 11:00 MSK
+    - cron: '0 8 * * 5' # run every Friday at 11:00 MSK
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Изменено расписание прогона пайплайна с тестами модулей: Terraform гонится по вторникам в 11, OpenTofu - по пятницам в 11;
- Бампнул версию экшна setup-terraform.