### PR TITLE
Ручная установка Terraform

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -10,6 +10,7 @@ jobs:
     name: 'Test Selectel Terraform modules'
     runs-on: self-hosted
     env:
+      terraform_link: https://releases.hashicorp.com/terraform/1.5.5/terraform_1.5.5_linux_amd64.zip
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
@@ -25,9 +26,16 @@ jobs:
         node-version: 20
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: "1.5.5"
+      shell: bash
+      run: |
+        curl -o terraform $terraform_link
+        chmod 755 terraform
+        mv terraform /usr/local/bin
+
+#    - name: Setup Terraform
+#      uses: hashicorp/setup-terraform@v3
+#      with:
+#        terraform_version: "1.5.5"
 
 #    - name: Run Checkov action # suppressed for now because it fails to copy a file inside a self-hosted runner
 #      uses: bridgecrewio/checkov-action@v12

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -28,7 +28,8 @@ jobs:
     - name: Setup Terraform
       shell: bash
       run: |
-        curl -o terraform $terraform_link
+        curl -o terraform.zip $terraform_link
+        tar -xzf terraform.zip
         chmod 755 terraform
         mv terraform /usr/local/bin
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -29,15 +29,9 @@ jobs:
       shell: bash
       run: |
         curl -o terraform.zip $terraform_link
-        apt-get install unzip
         unzip terraform.zip
         chmod 755 terraform
         mv terraform /usr/local/bin
-
-#    - name: Setup Terraform
-#      uses: hashicorp/setup-terraform@v3
-#      with:
-#        terraform_version: "1.5.5"
 
 #    - name: Run Checkov action # suppressed for now because it fails to copy a file inside a self-hosted runner
 #      uses: bridgecrewio/checkov-action@v12
@@ -80,17 +74,17 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-#    - name: Telegram notify if job was failed
-#      if: ${{ failure() }}
-#      uses: appleboy/telegram-action@master
-#      with:
-#        to: ${{ secrets.TELEGRAM_TO }}
-#        token: ${{ secrets.TELEGRAM_TOKEN }}
-#        message: |
-#          -= GITHUB public repository selectel/selectel-infra-examples =-
-#          Terraform modules build pipeline was failed
-#          🚨 Critical
-#          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
-#
-#          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-#          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+    - name: Telegram notify if job was failed
+      if: ${{ failure() }}
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        message: |
+          -= GITHUB public repository selectel/selectel-infra-examples =-
+          Terraform modules build pipeline was failed
+          🚨 Critical
+          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
+
+          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -29,7 +29,8 @@ jobs:
       shell: bash
       run: |
         curl -o terraform.zip $terraform_link
-        tar -xzf terraform.zip
+        apt-get install unzip
+        unzip terraform.zip
         chmod 755 terraform
         mv terraform /usr/local/bin
 
@@ -79,17 +80,17 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-    - name: Telegram notify if job was failed
-      if: ${{ failure() }}
-      uses: appleboy/telegram-action@master
-      with:
-        to: ${{ secrets.TELEGRAM_TO }}
-        token: ${{ secrets.TELEGRAM_TOKEN }}
-        message: |
-          -= GITHUB public repository selectel/selectel-infra-examples =-
-          Terraform modules build pipeline was failed
-          🚨 Critical
-          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
-
-          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+#    - name: Telegram notify if job was failed
+#      if: ${{ failure() }}
+#      uses: appleboy/telegram-action@master
+#      with:
+#        to: ${{ secrets.TELEGRAM_TO }}
+#        token: ${{ secrets.TELEGRAM_TOKEN }}
+#        message: |
+#          -= GITHUB public repository selectel/selectel-infra-examples =-
+#          Terraform modules build pipeline was failed
+#          🚨 Critical
+#          Не катится пайпа, необходимо принять меры, возможно внутренние пайпы с terraform так же не будут катиться.
+#
+#          ⚡️Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#          🔥 See changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         curl -o terraform.zip $terraform_link
         unzip terraform.zip
+        rm terraform.zip
         chmod 755 terraform
         mv terraform /usr/local/bin
 


### PR DESCRIPTION
- В пайплайне для теста модулей установка Terraform теперь проводится вручную, а не с помощью экшна hashicorp/setup-terraform, как раньше. Фиксит проблему, когда releases.hashicorp.com выдавал ошибку 404 при запросе внутри setup-terraform