### PR TITLE
Перенос бинарника Terraform в S3

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -10,7 +10,7 @@ jobs:
     name: 'Test Selectel Terraform modules'
     runs-on: self-hosted
     env:
-      terraform_link: https://ec04d1e1-8b8d-4782-97de-6a2107df181e.selstorage.ru/github_public/terraform_1.5.5_linux_amd64.zip
+      terraform_link: ${{ secrets.TERRAFORM_BINARY }}
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -10,7 +10,7 @@ jobs:
     name: 'Test Selectel Terraform modules'
     runs-on: self-hosted
     env:
-      terraform_link: https://releases.hashicorp.com/terraform/1.5.5/terraform_1.5.5_linux_amd64.zip
+      terraform_link: https://ec04d1e1-8b8d-4782-97de-6a2107df181e.selstorage.ru/github_public/terraform_1.5.5_linux_amd64.zip
       TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
       TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
       TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}


### PR DESCRIPTION
- Бинарник Terraform версии 1.5.5 перенесён в публичный бакет S3, теперь в пайплайне он берётся оттуда