### PR TITLE
Фиксы репозитория

### DIFF
--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -26,7 +26,7 @@ jobs:
         node-version: 20
 
     - name: Setup tfswitch
-      uses: stv-io/action-tfswitch@v1
+      uses: stv-io/action-tfswitch@v1.0.2
 
     - name: Install Terraform latest
       shell: bash

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install Terraform latest
       shell: bash
       run: |
-        tfswitch --latest --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
+        tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc
       shell: bash

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -43,15 +43,21 @@ jobs:
         }
         EOS
 
+    - name: Send test Telegram alert
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        message: |
+          ⚙️ GitHub repository selectel/selectel-infra-examples
+          
+          🔥 Test Alert
+
     - name: Init Terraform
       run: >
         terraform init -reconfigure
         -backend-config="bucket=github-terraform-state"
-        -backend-config="endpoint=s3.ru-1.storage.selcloud.ru"
         -backend-config="key=github-infra-examples.tfstate"
-        -backend-config="region=ru-1"
-        -backend-config="skip_region_validation=true"
-        -backend-config="skip_credentials_validation=true"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
 

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -8,10 +8,12 @@ jobs:
     name: 'Manual Destroy'
     runs-on: self-hosted
     env:
-      terraform_link: ${{ secrets.TERRAFORM_BINARY }}
-      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
-      TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
-      TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
+      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_DOMAIN_NAME }}
+      TF_VAR_selectel_user_name: ${{ secrets.SELECTEL_USER_NAME }}
+      TF_VAR_selectel_user_id: ${{ secrets.SELECTEL_USER_ID }}
+      TF_VAR_selectel_user_password: ${{ secrets.SELECTEL_USER_PASSWORD }}
+      TF_VAR_selectel_project_name: ${{ secrets.SELECTEL_PROJECT_NAME }}
+      TF_VAR_selectel_project_id: ${{ secrets.SELECTEL_PROJECT_ID }}
       TF_VAR_flavor_name: ${{ secrets.FLAVOR_NAME }}
 
     steps:
@@ -23,14 +25,13 @@ jobs:
       with:
         node-version: 20
 
-    - name: Setup Terraform
+    - name: Setup tfswitch
+      uses: stv-io/action-tfswitch@v1
+
+    - name: Install Terraform latest
       shell: bash
       run: |
-        curl -o terraform.zip $terraform_link
-        unzip terraform.zip
-        rm terraform.zip
-        chmod 755 terraform
-        mv terraform /usr/local/bin
+        tfswitch --latest --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc
       shell: bash
@@ -42,16 +43,6 @@ jobs:
             }
         }
         EOS
-
-    - name: Send test Telegram alert
-      uses: appleboy/telegram-action@master
-      with:
-        to: ${{ secrets.TELEGRAM_TO }}
-        token: ${{ secrets.TELEGRAM_TOKEN }}
-        message: |
-          ⚙️ GitHub repository selectel/selectel-infra-examples
-          
-          🔥 Test Alert
 
     - name: Init Terraform
       run: >

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Terraform latest
       shell: bash
       run: |
-        tfswitch --latest --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
+        tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc
       shell: bash

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -28,8 +28,6 @@ jobs:
 
     - name: Install Terraform latest
       shell: bash
-      # use -s 1.0 instead of --latest since apparently tfswitch relies on dirs creation date
-      # which is inconsistent for the selectel mirror. --latest gives v0.1.0 while -s 1.0 give latest
       run: |
         tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Terraform latest
       shell: bash
       # use -s 1.0 instead of --latest since apparently tfswitch relies on dirs creation date
-      # which is inconsistent for the selectel mirror. --latest gives v0.1.0 while -s 1.0 give latest ¯\_(ツ)_/¯
+      # which is inconsistent for the selectel mirror. --latest gives v0.1.0 while -s 1.0 give latest
       run: |
         tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,4 +1,4 @@
-name: 'Modules Test Run - Terraform v1.10.3'
+name: 'Modules Test Run - Terraform Latest'
 
 on:
   schedule:
@@ -7,13 +7,15 @@ on:
         
 jobs:
   setup:
-    name: 'Modules Test Run - Terraform v1.10.3'
+    name: 'Modules Test Run - Terraform Latest'
     runs-on: self-hosted
     env:
-      terraform_link: ${{ secrets.TERRAFORM_BINARY }}
-      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
-      TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
-      TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
+      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_DOMAIN_NAME }}
+      TF_VAR_selectel_user_name: ${{ secrets.SELECTEL_USER_NAME }}
+      TF_VAR_selectel_user_id: ${{ secrets.SELECTEL_USER_ID }}
+      TF_VAR_selectel_user_password: ${{ secrets.SELECTEL_USER_PASSWORD }}
+      TF_VAR_selectel_project_name: ${{ secrets.SELECTEL_PROJECT_NAME }}
+      TF_VAR_selectel_project_id: ${{ secrets.SELECTEL_PROJECT_ID }}
       TF_VAR_flavor_name: ${{ secrets.FLAVOR_NAME }}
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
 
@@ -21,28 +23,18 @@ jobs:
     - name: Checkout the repo
       uses: actions/checkout@v4
 
-    - name: Setup NodeJS v20
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+#    - name: Setup NodeJS v20
+#      uses: actions/setup-node@v4
+#      with:
+#        node-version: 20
 
-    - name: Setup Terraform
+    - name: Setup tfswitch
+      uses: stv-io/action-tfswitch@v1
+
+    - name: Install Terraform latest
       shell: bash
       run: |
-        curl -o terraform.zip $terraform_link
-        unzip terraform.zip
-        rm terraform.zip
-        chmod 755 terraform
-        mv terraform /usr/local/bin
-
-#    - name: Run Checkov action # suppressed for now because it fails to copy a file inside a self-hosted runner
-#      uses: bridgecrewio/checkov-action@v12
-#      with:
-#        quiet: true
-#        directory: .
-#        output_format: cli
-#        framework: terraform,github_actions
-#        container_user: 1000
+        tfswitch --latest --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc
       shell: bash
@@ -72,14 +64,15 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-    - name: Telegram notify if failed on main branch
+    - name: Send Telegram alert if failed on the main branch
       if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
-      uses: appleboy/telegram-action@master
+      uses: cbrgm/telegram-github-action@v1
       with:
         to: ${{ secrets.TELEGRAM_TO }}
         token: ${{ secrets.TELEGRAM_TOKEN }}
+        thread-id: 168
         message: |
-          ⚙️ *GitHub repository selectel/selectel-infra-examples*
-          
-          🔥 *Pipeline has failed*
-          ➡️ *Workflow:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ⚙️ GitHub repository selectel/selectel-infra-examples
+
+          🔥 Terraform pipeline has failed!
+          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -29,7 +29,7 @@ jobs:
 #        node-version: 20
 
     - name: Setup tfswitch
-      uses: stv-io/action-tfswitch@v1
+      uses: stv-io/action-tfswitch@v1.0.2
 
     - name: Install Terraform latest
       shell: bash

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Install Terraform latest
       shell: bash
-      run: |
       # use -s 1.0 instead of --latest since apparently tfswitch relies on dirs creation date
       # which is inconsistent for the selectel mirror. --latest gives v0.1.0 while -s 1.0 give latest ¯\_(ツ)_/¯
+      run: |
         tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -59,22 +59,8 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
-    - name: Send test Telegram alert
-      if: ${{ (success()) }}
-      uses: cbrgm/telegram-github-action@v1
-      with:
-        to: ${{ secrets.TELEGRAM_TO }}
-        token: ${{ secrets.TELEGRAM_TOKEN }}
-        thread-id: 168
-        message: |
-          ⚙️ GitHub repository selectel/selectel-infra-examples
-
-          🔥 Terraform pipeline has succeeded!
-          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
     - name: Send Telegram alert if failed on the main branch
-      if: ${{ (failure()) }}
-      # if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
+      if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
       uses: cbrgm/telegram-github-action@v1
       with:
         to: ${{ secrets.TELEGRAM_TO }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -64,8 +64,22 @@ jobs:
     - name: Terraform destroy
       run: terraform destroy -auto-approve
 
+    - name: Send test Telegram alert
+      if: ${{ (success()) }}
+      uses: cbrgm/telegram-github-action@v1
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        thread-id: 168
+        message: |
+          ⚙️ GitHub repository selectel/selectel-infra-examples
+
+          🔥 Terraform pipeline has succeeded!
+          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     - name: Send Telegram alert if failed on the main branch
-      if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
+      if: ${{ (failure()) }}
+      # if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
       uses: cbrgm/telegram-github-action@v1
       with:
         to: ${{ secrets.TELEGRAM_TO }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -23,17 +23,14 @@ jobs:
     - name: Checkout the repo
       uses: actions/checkout@v4
 
-#    - name: Setup NodeJS v20
-#      uses: actions/setup-node@v4
-#      with:
-#        node-version: 20
-
     - name: Setup tfswitch
       uses: stv-io/action-tfswitch@v1.0.2
 
     - name: Install Terraform latest
       shell: bash
       run: |
+      # use -s 1.0 instead of --latest since apparently tfswitch relies on dirs creation date
+      # which is inconsistent for the selectel mirror. --latest gives v0.1.0 while -s 1.0 give latest ¯\_(ツ)_/¯
         tfswitch -s 1.0 --mirror https://mirror.selectel.ru/3rd-party/hashicorp-releases/terraform
 
     - name: Add .terraformrc

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -54,22 +54,8 @@ jobs:
     - name: OpenTofu destroy
       run: tofu destroy -auto-approve
 
-    - name: Send test Telegram alert
-      if: ${{ (success()) }}
-      uses: cbrgm/telegram-github-action@v1
-      with:
-        to: ${{ secrets.TELEGRAM_TO }}
-        token: ${{ secrets.TELEGRAM_TOKEN }}
-        thread-id: 168
-        message: |
-          ⚙️ GitHub repository selectel/selectel-infra-examples
-          
-          🔥 OpenTofu pipeline has succeeded!
-          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
     - name: Send Telegram alert if failed on the main branch
-      if: ${{ (failure()) }}
-      # if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
+      if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
       uses: cbrgm/telegram-github-action@v1
       with:
         to: ${{ secrets.TELEGRAM_TO }}

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -54,8 +54,22 @@ jobs:
     - name: OpenTofu destroy
       run: tofu destroy -auto-approve
 
+    - name: Send test Telegram alert
+      if: ${{ (success()) }}
+      uses: cbrgm/telegram-github-action@v1
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        thread-id: 168
+        message: |
+          ⚙️ GitHub repository selectel/selectel-infra-examples
+          
+          🔥 OpenTofu pipeline has succeeded!
+          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     - name: Send Telegram alert if failed on the main branch
-      if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
+      if: ${{ (failure()) }}
+      # if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
       uses: cbrgm/telegram-github-action@v1
       with:
         to: ${{ secrets.TELEGRAM_TO }}

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -10,9 +10,12 @@ jobs:
     name: 'Modules Test Run - OpenTofu Latest'
     runs-on: self-hosted
     env:
-      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_ID }}
-      TF_VAR_selectel_user_admin_user: ${{ secrets.SERVICE_USER }}
-      TF_VAR_selectel_user_admin_password: ${{ secrets.SERVICE_PASSWORD }}
+      TF_VAR_selectel_domain_name: ${{ secrets.SELECTEL_DOMAIN_NAME }}
+      TF_VAR_selectel_user_name: ${{ secrets.SELECTEL_USER_NAME }}
+      TF_VAR_selectel_user_id: ${{ secrets.SELECTEL_USER_ID }}
+      TF_VAR_selectel_user_password: ${{ secrets.SELECTEL_USER_PASSWORD }}
+      TF_VAR_selectel_project_name: ${{ secrets.SELECTEL_PROJECT_NAME }}
+      TF_VAR_selectel_project_id: ${{ secrets.SELECTEL_PROJECT_ID }}
       TF_VAR_flavor_name: ${{ secrets.FLAVOR_NAME }}
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
 
@@ -50,3 +53,16 @@ jobs:
 
     - name: OpenTofu destroy
       run: tofu destroy -auto-approve
+
+    - name: Send Telegram alert if failed on the main branch
+      if: ${{ (failure()) && (github.ref == 'refs/heads/main') }}
+      uses: cbrgm/telegram-github-action@v1
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        thread-id: 168
+        message: |
+          ⚙️ GitHub repository selectel/selectel-infra-examples
+
+          🔥 OpenTofu pipeline has failed!
+          ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Selectel Terraform Modules Example
 
-|                   | Pipeline Status                                                                                                                                                                         | Version                                                                                                                            |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| Terraform v1.10.3 | [![](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml)   | [![version](https://img.shields.io/badge/Terraform-1.10.3-green.svg)](https://github.com/hashicorp/terraform/releases/tag/v1.10.3) |
-| OpenTofu Latest   | [![](https://github.com/selectel/selectel-infra-examples/actions/workflows/opentofu.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/opentofu.yml) | [![version](https://img.shields.io/badge/OpenTofu-Latest-green.svg)](https://github.com/opentofu/opentofu/releases/latest)         |
+|                   | Pipeline Status                                                                                                                                                                         | Version                                                                                                                       |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Terraform Latest | [![](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/modules.yml)   | [![version](https://img.shields.io/badge/Terraform-Latest-green.svg)](https://github.com/hashicorp/terraform/releases/latest) |
+| OpenTofu Latest   | [![](https://github.com/selectel/selectel-infra-examples/actions/workflows/opentofu.yml/badge.svg)](https://github.com/selectel/selectel-infra-examples/actions/workflows/opentofu.yml) | [![version](https://img.shields.io/badge/OpenTofu-Latest-green.svg)](https://github.com/opentofu/opentofu/releases/latest)    |
 
 - [Selectel Terraform Modules Example](#selectel-terraform-modules-example)
   - [Использование](#использование)
@@ -14,11 +14,15 @@
   - [Структура репозитория](#структура-репозитория)
     - [Modules](#modules)
 
-В [данном репозитории](https://github.com/selectel/selectel-infra-examples) находятся примеры Terraform модулей, используемых для создания инфраструктуры в облаке Selectel. Также в репозитории еженедельно запускаются пайплайны с тестовым созданием ресурсов с помощью **Terraform** и **OpenTofu**.
+В [данном репозитории](https://github.com/selectel/selectel-infra-examples) находятся примеры Terraform модулей, используемых для создания инфраструктуры в 
+облаке Selectel. Также в репозитории еженедельно запускаются пайплайны с тестовым созданием ресурсов с помощью 
+**Terraform** и **OpenTofu**.
 
-**P.S.** Если вы не нашли пример для создания определенного ресурса - можете оставить issue и мы примем во внимание необходимость его добавления.
+**P.S.** Если вы не нашли пример для создания определенного ресурса - можете оставить issue и мы примем во 
+внимание необходимость его добавления.
 
-Перед началом работы с облачными ресурсами Selectel через Terraform/OpenTofu рекомендуем ознакомиться с [документацией по провайдеру Selectel/OpenStack](https://docs.selectel.ru/terraform/).
+Перед началом работы с облачными ресурсами Selectel через Terraform/OpenTofu рекомендуем ознакомиться с 
+[документацией по провайдеру Selectel/OpenStack](https://docs.selectel.ru/terraform/).
 
 ## Использование
 
@@ -28,7 +32,8 @@
 
 ### 1. .terraformrc/.tofurc
 
-Для доступа к Terraform Registry из РФ можно воспользоваться кеширующим прокси Selectel, для этого отредактируем файл .terraformrc (или .tofurc для OpenTofu):
+Для доступа к Terraform Registry из РФ можно воспользоваться кеширующим прокси Selectel, для этого отредактируем 
+файл .terraformrc (или .tofurc для OpenTofu):
 
 ```bash
 cat <<EOS >> $HOME/.terraformrc
@@ -42,7 +47,8 @@ EOS
 
 ### 2. State File
 
-По умолчанию в репозитории стейт хранится в s3, для локального запуска потребуется изменить поле `backend` на `local` в файле [versions.tf](https://github.com/selectel/selectel-infra-examples/blob/main/versions.tf#L12):
+По умолчанию в репозитории стейт хранится в s3, для локального запуска потребуется изменить поле `backend` на 
+`local` в файле [versions.tf](https://github.com/selectel/selectel-infra-examples/blob/main/versions.tf#L12):
 
 ```terraform
 terraform {
@@ -73,25 +79,10 @@ terraform {
 
 ### 3. Init
 
-Вы можете использовать все модули, которые есть в репозитории или закомментировать лишние, но учтите, что **в первую очередь создается проект с сервисным пользователем**, которые необходимы для провайдера `Openstack`. 
+Для начала работы необходимо создать в Панели Управления проект, в котором будут впоследствии создаваться ресурсы,
+а также сервисного пользователя с ролью Администратор проекта для вышеупомянутого проекта. Далее необходимо 
+отредактировать `main.tf`, оставив в нём необходимые ресурсы, после чего:
 
->Все, что будет создано ресурсами из провайдера `Openstack` должно идти после создания проекта и пользователя! Для этого потребуется добавить `depends_on` к ресурсу:
-> ```terraform
-> depends_on = [ module.project-with-user ]
-> ```
-
-**Опционально:** Создаем файл `main.tf`, где описана необходимая инфраструктура (пример ниже - создание `Simple File Storage`, остальные примеры смотри в папке [modules](https://github.com/selectel/selectel-infra-examples/tree/main/modules)):
-
-```yaml
-module "sfs" {
-  source               = "modules/sfs"
-  os_network_id        = var.nat_network_id
-  os_subnet_id         = var.nat_subnet_id
-  sfs_size             = var.sfs_size
-  sfs_volume_type      = var.sfs_volume_type
-  os_availability_zone = var.os_availability_zone
-}
-```
 
 1. Инициализируем Terraform Backend командой:
 
@@ -113,7 +104,8 @@ terraform apply
 
 ## Пример использования
 
-В репозитории можно найти пример использования модулей. В корне репозитория созданы `*.tf` файлы, которые можно использовать как пример вызова модулей.
+В репозитории можно найти пример использования модулей. В корне репозитория созданы `*.tf` файлы, которые можно 
+использовать как пример вызова модулей.
 
 Для их использования достаточно перейти в корень репозитория и инициализировать Terraform:
 
@@ -121,13 +113,18 @@ terraform apply
 terraform init
 ```
 
-Далее можно скорректировать некоторые параметры в файле `main.tf`, которые передаются в модули, например, объём SFS, имя кластера и другие.
+Далее можно скорректировать некоторые параметры в файле `main.tf`, которые передаются в модули, например, объём 
+SFS, имя кластера и другие.
 
-Затем необходимо задать переменные, в которых будут содержаться данные от аккаунта Selectel, в котором будет развёрнута инфраструктура:
+Затем необходимо задать переменные, в которых будут содержаться данные от аккаунта Selectel, в котором будет 
+развёрнута инфраструктура:
 
-- `selectel_domain_name`, ID аккаунта, например, 123123
-- `selectel_user_admin_user`, сервисный пользователь с нужными правами 
-- `selectel_user_admin_password`, пароль от сервисного пользователя
+- `selectel_domain_name` - ID Selectel-аккаунта;
+- `selectel_project_name` - название проекта;
+- `selectel_project_id` - ID проекта;
+- `selectel_user_name` - имя сервисного пользователя; 
+- `selectel_user_id` - UID сервисного пользователя;
+- `selectel_user_password` - пароль сервисного пользователя.
 
 Переменные можно задать несколькими способами:
 
@@ -135,8 +132,11 @@ terraform init
 
 ```bash
 export TF_VAR_selectel_domain_name=123123
-export TF_VAR_selectel_user_admin_user=foo
-export TF_VAR_selectel_user_admin_password=bar
+export TF_VAR_selectel_project_name=Project
+export TF_VAR_selectel_project_id=abcd1234abcd1234abcd1234abcd1234
+export TF_VAR_selectel_user_name=foo
+export TF_VAR_selectel_user_id=1234abcd1234abcd1234abcd1234abcd
+export TF_VAR_selectel_user_password=bar
 terraform plan/apply
 ```
 - Ввести вместе с командой `terraform plan/apply` с помощью параметра `-var`:
@@ -144,17 +144,21 @@ terraform plan/apply
 ```bash
 terraform plan/apply \
 -var="selectel_domain_name=123123" \
--var="selectel_user_admin_user=foo" \
--var="selectel_user_admin_password=bar"
+-var="selectel_project_name=Project" \
+-var="selectel_project_id=abcd1234abcd1234abcd1234abcd1234" \
+-var="selectel_user_name=foo" \
+-var="selectel_user_id=1234abcd1234abcd1234abcd1234abcd" \
+-var="selectel_user_password=bar"
 ```
 
 - Ввести с клавиатуры, если переменные не были заданы любым другим способом
 
-После успешного выполнения команды `terraform apply` вы должны увидеть в своём аккаунте новый проект, в котором будут запущены все модули (MKS, SFS, vm, CRaaS и др.)
+После успешного выполнения команды `terraform apply` в заданном проекте появятся указанные в `main.tf` ресурсы.
 
 ## Структура репозитория
 
-Репозиторий включает в себя минимально необходимую структуру для запуска Terraform. В директории [modules](https://github.com/selectel/selectel-infra-examples/tree/main/modules) собраны модули для создания различных компонентов в облаке Selectel.
+Репозиторий включает в себя минимально необходимую структуру для запуска Terraform. В директории [modules](https://github.com/selectel/selectel-infra-examples/tree/main/modules) 
+собраны модули для создания различных компонентов в облаке Selectel.
 
 ### Modules
 

--- a/README_TF.md
+++ b/README_TF.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | 3.0.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 6.0.1 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | 6.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_openstack"></a> [openstack](#provider\_openstack) | 3.0.0 |
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 6.0.1 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | 6.4.0 |
 
 ## Modules
 
@@ -20,7 +20,6 @@
 | <a name="module_craas"></a> [craas](#module\_craas) | ./modules/craas | n/a |
 | <a name="module_fl_ip"></a> [fl\_ip](#module\_fl\_ip) | ./modules/floatingip | n/a |
 | <a name="module_mks"></a> [mks](#module\_mks) | ./modules/mks/k8s-cluster-standalone | n/a |
-| <a name="module_project-with-user"></a> [project-with-user](#module\_project-with-user) | ./modules/os_project_with_user | n/a |
 | <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | ./modules/s3/s3-bucket | n/a |
 | <a name="module_s3-creds"></a> [s3-creds](#module\_s3-creds) | ./modules/s3/s3-credentials | n/a |
 | <a name="module_sfs"></a> [sfs](#module\_sfs) | ./modules/sfs | n/a |
@@ -40,8 +39,11 @@
 | <a name="input_flavor_name"></a> [flavor\_name](#input\_flavor\_name) | Название флавора | `string` | `"1013"` | no |
 | <a name="input_os_auth_url"></a> [os\_auth\_url](#input\_os\_auth\_url) | URL до openstack api | `string` | `"https://cloud.api.selcloud.ru/identity/v3"` | no |
 | <a name="input_selectel_domain_name"></a> [selectel\_domain\_name](#input\_selectel\_domain\_name) | ID Selectel аккаунта | `string` | n/a | yes |
-| <a name="input_selectel_user_admin_password"></a> [selectel\_user\_admin\_password](#input\_selectel\_user\_admin\_password) | Пароль от сервисного пользователя | `string` | n/a | yes |
-| <a name="input_selectel_user_admin_user"></a> [selectel\_user\_admin\_user](#input\_selectel\_user\_admin\_user) | Имя сервисного пользователя, необходимо создать через панель my.selectel | `string` | n/a | yes |
+| <a name="input_selectel_project_id"></a> [selectel\_project\_id](#input\_selectel\_project\_id) | ID проекта | `string` | n/a | yes |
+| <a name="input_selectel_project_name"></a> [selectel\_project\_name](#input\_selectel\_project\_name) | Название проекта | `string` | n/a | yes |
+| <a name="input_selectel_user_id"></a> [selectel\_user\_id](#input\_selectel\_user\_id) | ID сервисного пользователя | `string` | n/a | yes |
+| <a name="input_selectel_user_name"></a> [selectel\_user\_name](#input\_selectel\_user\_name) | Имя сервисного пользователя | `string` | n/a | yes |
+| <a name="input_selectel_user_password"></a> [selectel\_user\_password](#input\_selectel\_user\_password) | Пароль сервисного пользователя | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -22,13 +22,15 @@ module "sfs" {
 
 # S3 нет в провайдере Selectel, поэтому под капотом terracurl
 
-# Создаём S3-ключ для пользователя
-module "s3-creds" {
-  source           = "./modules/s3/s3-credentials"
-  os_user_id       = var.selectel_user_id
-  os_project_id    = var.selectel_project_id
-  credentials_name = "github-s3-creds"
-}
+# Сервисный пользователь не может выписывать сам на себя S3-ключи,
+# поэтому остаётся только ручное создание через панель.
+# More info: https://docs.selectel.ru/cloud/object-storage/manage/manage-access/#issue-s3-key
+# module "s3-creds" {
+#   source           = "./modules/s3/s3-credentials"
+#   os_user_id       = var.selectel_user_id
+#   os_project_id    = var.selectel_project_id
+#   credentials_name = "github-s3-creds"
+# }
 
 # Создаём S3-bucket
 module "s3-bucket" {

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,3 @@
-# Запуск модулей
-
-# Создаём проект с пользователем
-module "project-with-user" {
-  source          = "./modules/os_project_with_user"
-  os_project_name = "gh_test_tf_modules"
-  os_username     = "gh_test_tf_user"
-}
-
 # Создаём виртуалку и всё, что необходимо для её работы
 module "vm" {
   source              = "./modules/vm"
@@ -17,10 +8,6 @@ module "vm" {
   vm_vcpus            = 4
   vm_ram_mb           = 4096
   enable_dhcp         = true
-
-  depends_on = [
-    module.project-with-user
-  ]
 }
 
 # Создаём simple file storage в той же сети, где находится виртуальная машина
@@ -31,10 +18,6 @@ module "sfs" {
   sfs_volume_type      = "basic"
   os_network_id        = module.vm.nat_net_id
   os_subnet_id         = module.vm.nat_sub_id
-
-  depends_on = [
-    module.vm
-  ]
 }
 
 # S3 нет в провайдере Selectel, поэтому под капотом terracurl
@@ -42,39 +25,27 @@ module "sfs" {
 # Создаём S3-ключ для пользователя
 module "s3-creds" {
   source           = "./modules/s3/s3-credentials"
-  os_user_id       = module.project-with-user.user_id
-  os_project_id    = module.project-with-user.project_id
+  os_user_id       = var.selectel_user_id
+  os_project_id    = var.selectel_project_id
   credentials_name = "github-s3-creds"
-
-  depends_on = [
-    module.project-with-user
-  ]
 }
 
 # Создаём S3-bucket
 module "s3-bucket" {
   source          = "./modules/s3/s3-bucket"
   os_account      = var.selectel_domain_name
-  os_username     = module.project-with-user.user_name
-  os_password     = module.project-with-user.user_password
-  os_project_id   = module.project-with-user.project_id
-  os_project_name = module.project-with-user.project_name
+  os_username     = var.selectel_user_name
+  os_password     = var.selectel_user_password
+  os_project_id   = var.selectel_project_id
+  os_project_name = var.selectel_project_name
   s3_bucket_name  = "github-s3-bucket"
-
-  depends_on = [
-    module.project-with-user
-  ]
 }
 
 # Создаём CRaaS
 module "craas" {
   source        = "./modules/craas"
-  os_project_id = module.project-with-user.project_id
+  os_project_id = var.selectel_project_id
   token_ttl     = "1y"
-
-  depends_on = [
-    module.project-with-user
-  ]
 }
 
 # Аттачим floating IP к виртуалке
@@ -101,7 +72,7 @@ resource "openstack_networking_floatingip_associate_v2" "association_1" {
 
 # Запрашиваем данные, из которых позже возьмём последнюю версию K8s
 data "selectel_mks_kube_versions_v1" "versions" {
-  project_id = module.project-with-user.project_id
+  project_id = var.selectel_project_id
   region     = "ru-9"
 }
 
@@ -114,7 +85,7 @@ module "mks" {
 
   os_availability_zone = "ru-9a"
   os_region            = "ru-9"
-  os_project_id        = module.project-with-user.project_id
+  os_project_id        = var.selectel_project_id
 
   nodegroups     = 1
   ng_nodes_count = [1]
@@ -134,8 +105,4 @@ module "mks" {
   nat_subnet_cidr   = "10.222.0.0/16"
   enable_autorepair = false
   network_id        = ""
-
-  depends_on = [
-    module.project-with-user
-  ]
 }

--- a/modules/craas/README.md
+++ b/modules/craas/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/craas/versions.tf
+++ b/modules/craas/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/mks/k8s-cluster-standalone/README.md
+++ b/modules/mks/k8s-cluster-standalone/README.md
@@ -2,15 +2,15 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+|------|--------|
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | ~> 3.0.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/mks/k8s-cluster-standalone/versions.tf
+++ b/modules/mks/k8s-cluster-standalone/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"

--- a/modules/mks/k8s-cluster/README.md
+++ b/modules/mks/k8s-cluster/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/mks/k8s-cluster/versions.tf
+++ b/modules/mks/k8s-cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/mks/k8s-nodegroup-gpu/README.md
+++ b/modules/mks/k8s-nodegroup-gpu/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/mks/k8s-nodegroup-gpu/versions.tf
+++ b/modules/mks/k8s-nodegroup-gpu/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/mks/k8s-nodegroup/README.md
+++ b/modules/mks/k8s-nodegroup/README.md
@@ -3,13 +3,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0  |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/mks/k8s-nodegroup/versions.tf
+++ b/modules/mks/k8s-nodegroup/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/os_project_with_user/README.md
+++ b/modules/os_project_with_user/README.md
@@ -2,16 +2,16 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+|------|--------|
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+|------|--------|
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/os_project_with_user/versions.tf
+++ b/modules/os_project_with_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"

--- a/modules/s3/s3-credentials/README.md
+++ b/modules/s3/s3-credentials/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0.0 |
+|------|--------|
+| <a name="provider_selectel"></a> [selectel](#provider\_selectel) | ~> 6.0 |
 
 ## Modules
 

--- a/modules/s3/s3-credentials/versions.tf
+++ b/modules/s3/s3-credentials/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -2,9 +2,9 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+|------|--------|
 | <a name="requirement_openstack"></a> [openstack](#requirement\_openstack) | ~> 3.0.0 |
-| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0.0 |
+| <a name="requirement_selectel"></a> [selectel](#requirement\_selectel) | ~> 6.0 |
 
 ## Providers
 

--- a/modules/vm/versions.tf
+++ b/modules/vm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "~> 6.0.0"
+      version = "~> 6.0"
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"

--- a/providers.tf
+++ b/providers.tf
@@ -1,16 +1,16 @@
 provider "selectel" {
   domain_name = var.selectel_domain_name
-  username    = var.selectel_user_admin_user
-  password    = var.selectel_user_admin_password
+  username    = var.selectel_user_name
+  password    = var.selectel_user_password
   auth_url    = var.os_auth_url
   auth_region = "ru-9"
 }
 
 provider "openstack" {
   auth_url            = var.os_auth_url
-  user_name           = module.project-with-user.user_name
-  tenant_id           = module.project-with-user.project_id
-  password            = module.project-with-user.user_password
+  user_name           = var.selectel_user_name
+  tenant_id           = var.selectel_project_id
+  password            = var.selectel_user_password
   project_domain_name = var.selectel_domain_name
   user_domain_name    = var.selectel_domain_name
   region              = "ru-9"

--- a/vars.tf
+++ b/vars.tf
@@ -4,14 +4,30 @@ variable "selectel_domain_name" {
   description = "ID Selectel аккаунта"
 }
 
-variable "selectel_user_admin_user" {
+variable "selectel_user_name" {
   type        = string
-  description = "Имя сервисного пользователя, необходимо создать через панель my.selectel"
+  description = "Имя сервисного пользователя"
 }
 
-variable "selectel_user_admin_password" {
+variable "selectel_user_id" {
   type        = string
-  description = "Пароль от сервисного пользователя"
+  description = "ID сервисного пользователя"
+}
+
+variable "selectel_user_password" {
+  type        = string
+  description = "Пароль сервисного пользователя"
+  sensitive   = true
+}
+
+variable "selectel_project_name" {
+  type        = string
+  description = "Название проекта"
+}
+
+variable "selectel_project_id" {
+  type        = string
+  description = "ID проекта"
 }
 
 # Openstack provider vars

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "6.0.1"
+      version = "6.4.0"
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"


### PR DESCRIPTION
- Починен воркфлоу Manual Destroy в разделе настройки backend у Terraform init;
- Во все воркфлоу, использующие Terraform, добавлено использование tfswitch в связке с зеркалом Selectel;
- Terraform-воркфлоу теперь использует latest версию Terraform вместо захардкоженной;
- Заменён экшн для отправки алертов в Telegram, поскольку предыдущий не поддерживал чаты с топиками;
- Обновлён провайдер Selectel до версии 6.4.0;
- Изменена логика работы основного main.tf - теперь он не создаёт новый проект и сервисного пользователя, а использует текущие;
- Обновлён основной README.md и прочие readme от terraform-docs.