### PR TITLE
Фикс OpenTofu; обновление провайдеров

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -71,3 +71,4 @@ jobs:
 
           🔥 Terraform pipeline has failed!
           ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        disable-web-page-preview: true

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -66,3 +66,4 @@ jobs:
 
           🔥 OpenTofu pipeline has failed!
           ➡️ Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        disable-web-page-preview: true

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Setup OpenTofu
       uses: opentofu/setup-opentofu@v1
+      with:
+        tofu_version: 1.10.0
 
     - name: Add .tofurc
       shell: bash

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -25,8 +25,6 @@ jobs:
 
     - name: Setup OpenTofu
       uses: opentofu/setup-opentofu@v1
-      with:
-        tofu_version: 1.10.0
 
     - name: Add .tofurc
       shell: bash
@@ -49,6 +47,11 @@ jobs:
         -backend-config="key=github-infra-examples.tfstate"
         -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
         -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
+
+    - name: Copy Terraform providers to OpenTofu registry path
+      run: |
+        mkdir -p .terraform/providers/registry.opentofu.org
+        cp -r .terraform/providers/registry.terraform.io/* .terraform/providers/registry.opentofu.org/
 
     - name: OpenTofu apply
       run: tofu apply -auto-approve

--- a/modules/flavor/versions.tf
+++ b/modules/flavor/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/floatingip/versions.tf
+++ b/modules/floatingip/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/image_datasource/versions.tf
+++ b/modules/image_datasource/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/keypair/versions.tf
+++ b/modules/keypair/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/mks/k8s-cluster-standalone/versions.tf
+++ b/modules/mks/k8s-cluster-standalone/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/nat/versions.tf
+++ b/modules/nat/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/os_project_with_user/versions.tf
+++ b/modules/os_project_with_user/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = "~> 3.6.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/s3/s3-bucket/versions.tf
+++ b/modules/s3/s3-bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
     http-full = {
       source  = "registry.terraform.io/salrashid123/http-full"

--- a/modules/sfs/versions.tf
+++ b/modules/sfs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/vm/versions.tf
+++ b/modules/vm/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/volume/versions.tf
+++ b/modules/volume/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = "~> 3.6.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     selectel = {
       source  = "registry.terraform.io/selectel/selectel"
-      version = "6.4.0"
+      version = "6.5.0"
     }
     openstack = {
       source  = "registry.terraform.io/terraform-provider-openstack/openstack"
-      version = "3.0.0"
+      version = "3.2.0"
     }
   }
   backend "s3" {


### PR DESCRIPTION
- Добавлен хак, позволяющий не падать OpenTofu при тестовом прогоне;
- Обновлены провайдеры OS, Selectel и вспомогательные;
- Изменён темлейт сообщения об ошибке в Telegram.